### PR TITLE
lift dependency range for containers to <=0.6.0.1

### DIFF
--- a/wl-pprint-extras.cabal
+++ b/wl-pprint-extras.cabal
@@ -24,7 +24,7 @@ library
 
   build-depends:
     base          == 4.*,
-    containers    >= 0.4     && < 0.6,
+    containers    >= 0.4     && <= 0.6.0.1,
     nats          >= 0.1     && < 2,
     semigroups    >= 0.9     && < 1,
     semigroupoids >= 3       && < 6,


### PR DESCRIPTION
As mentioned in https://github.com/ekmett/wl-pprint-extras/issues/17 GHC 8.6 needs containers-0.6.0.1. Increasing the range here would also improve the situation with other packages that rely on wl-pprint-extras (e.g. HaTex).